### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ frigg-worker to detect coverage from test runs. ::
 .. |coverage| image:: https://ci.frigg.io/badges/coverage/frigg/frigg-coverage/
     :target: https://ci.frigg.io/frigg/frigg-coverage/last/
 
-.. |version| image:: https://pypip.in/version/frigg-coverage/badge.svg?style=flat
+.. |version| image:: https://img.shields.io/pypi/v/frigg-coverage.svg?style=flat
     :target: https://pypi.python.org/pypi/frigg-coverage/
     :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20frigg-coverage))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `frigg-coverage`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.